### PR TITLE
Fix bad references to private member ILuaBase::state

### DIFF
--- a/source/crypt.cpp
+++ b/source/crypt.cpp
@@ -686,7 +686,7 @@ static const char *invalid_error = "invalid crypter";
 inline void CheckType( GarrysMod::Lua::ILuaBase *LUA, int32_t index )
 {
 	if( !LUA->IsType( index, metatype ) )
-		luaL_typerror( LUA->state, index, metaname );
+		luaL_typerror( LUA->GetState(), index, metaname );
 }
 
 static Crypter *GetUserData( GarrysMod::Lua::ILuaBase *LUA, int32_t index )
@@ -709,11 +709,11 @@ LUA_FUNCTION_STATIC( tostring )
 
 #if defined _WIN32
 
-	lua_pushfstring( LUA->state, "%s: %p", metaname, Get( LUA, 1 ) );
+	lua_pushfstring( LUA->GetState(), "%s: %p", metaname, Get( LUA, 1 ) );
 
 #elif defined __linux || defined __APPLE__
 
-	lua_pushfstring( LUA->state, "%s: 0x%p", metaname, Get( LUA, 1 ) );
+	lua_pushfstring( LUA->GetState(), "%s: 0x%p", metaname, Get( LUA, 1 ) );
 
 #endif
 
@@ -738,7 +738,7 @@ LUA_FUNCTION_STATIC( index )
 
 	LUA->Pop( 2 );
 
-	lua_getfenv( LUA->state, 1 );
+	lua_getfenv( LUA->GetState(), 1 );
 	LUA->Push( 2 );
 	LUA->RawGet( -2 );
 	return 1;
@@ -748,7 +748,7 @@ LUA_FUNCTION_STATIC( newindex )
 {
 	CheckType( LUA, 1 );
 
-	lua_getfenv( LUA->state, 1 );
+	lua_getfenv( LUA->GetState(), 1 );
 	LUA->Push( 2 );
 	LUA->Push( 3 );
 	LUA->RawSet( -3 );

--- a/source/crypt.cpp
+++ b/source/crypt.cpp
@@ -686,7 +686,7 @@ static const char *invalid_error = "invalid crypter";
 inline void CheckType( GarrysMod::Lua::ILuaBase *LUA, int32_t index )
 {
 	if( !LUA->IsType( index, metatype ) )
-		luaL_typerror( LUA->GetState(), index, metaname );
+		luaL_typerror( LUA->GetState( ), index, metaname );
 }
 
 static Crypter *GetUserData( GarrysMod::Lua::ILuaBase *LUA, int32_t index )
@@ -709,11 +709,11 @@ LUA_FUNCTION_STATIC( tostring )
 
 #if defined _WIN32
 
-	lua_pushfstring( LUA->GetState(), "%s: %p", metaname, Get( LUA, 1 ) );
+	lua_pushfstring( LUA->GetState( ), "%s: %p", metaname, Get( LUA, 1 ) );
 
 #elif defined __linux || defined __APPLE__
 
-	lua_pushfstring( LUA->GetState(), "%s: 0x%p", metaname, Get( LUA, 1 ) );
+	lua_pushfstring( LUA->GetState( ), "%s: 0x%p", metaname, Get( LUA, 1 ) );
 
 #endif
 
@@ -738,7 +738,7 @@ LUA_FUNCTION_STATIC( index )
 
 	LUA->Pop( 2 );
 
-	lua_getfenv( LUA->GetState(), 1 );
+	lua_getfenv( LUA->GetState( ), 1 );
 	LUA->Push( 2 );
 	LUA->RawGet( -2 );
 	return 1;
@@ -748,7 +748,7 @@ LUA_FUNCTION_STATIC( newindex )
 {
 	CheckType( LUA, 1 );
 
-	lua_getfenv( LUA->GetState(), 1 );
+	lua_getfenv( LUA->GetState( ), 1 );
 	LUA->Push( 2 );
 	LUA->Push( 3 );
 	LUA->RawSet( -3 );

--- a/source/hash.cpp
+++ b/source/hash.cpp
@@ -23,7 +23,7 @@ static const char *invalid_error = "invalid hasher";
 inline void CheckType( GarrysMod::Lua::ILuaBase *LUA, int32_t index )
 {
 	if( !LUA->IsType( index, metatype ) )
-		luaL_typerror( LUA->GetState(), index, metaname );
+		luaL_typerror( LUA->GetState( ), index, metaname );
 }
 
 static CryptoPP::HashTransformation *GetUserData( GarrysMod::Lua::ILuaBase *LUA, int32_t index )
@@ -46,11 +46,11 @@ LUA_FUNCTION_STATIC( tostring )
 
 #if defined _WIN32
 
-	lua_pushfstring( LUA->GetState(), "%s: %p", metaname, Get( LUA, 1 ) );
+	lua_pushfstring( LUA->GetState( ), "%s: %p", metaname, Get( LUA, 1 ) );
 
 #elif defined __linux || defined __APPLE__
 
-	lua_pushfstring( LUA->GetState(), "%s: 0x%p", metaname, Get( LUA, 1 ) );
+	lua_pushfstring( LUA->GetState( ), "%s: 0x%p", metaname, Get( LUA, 1 ) );
 
 #endif
 
@@ -75,7 +75,7 @@ LUA_FUNCTION_STATIC( index )
 
 	LUA->Pop( 2 );
 
-	lua_getfenv( LUA->GetState(), 1 );
+	lua_getfenv( LUA->GetState( ), 1 );
 	LUA->Push( 2 );
 	LUA->RawGet( -2 );
 	return 1;
@@ -85,7 +85,7 @@ LUA_FUNCTION_STATIC( newindex )
 {
 	CheckType( LUA, 1 );
 
-	lua_getfenv( LUA->GetState(), 1 );
+	lua_getfenv( LUA->GetState( ), 1 );
 	LUA->Push( 2 );
 	LUA->Push( 3 );
 	LUA->RawSet( -3 );

--- a/source/hash.cpp
+++ b/source/hash.cpp
@@ -23,7 +23,7 @@ static const char *invalid_error = "invalid hasher";
 inline void CheckType( GarrysMod::Lua::ILuaBase *LUA, int32_t index )
 {
 	if( !LUA->IsType( index, metatype ) )
-		luaL_typerror( LUA->state, index, metaname );
+		luaL_typerror( LUA->GetState(), index, metaname );
 }
 
 static CryptoPP::HashTransformation *GetUserData( GarrysMod::Lua::ILuaBase *LUA, int32_t index )
@@ -46,11 +46,11 @@ LUA_FUNCTION_STATIC( tostring )
 
 #if defined _WIN32
 
-	lua_pushfstring( LUA->state, "%s: %p", metaname, Get( LUA, 1 ) );
+	lua_pushfstring( LUA->GetState(), "%s: %p", metaname, Get( LUA, 1 ) );
 
 #elif defined __linux || defined __APPLE__
 
-	lua_pushfstring( LUA->state, "%s: 0x%p", metaname, Get( LUA, 1 ) );
+	lua_pushfstring( LUA->GetState(), "%s: 0x%p", metaname, Get( LUA, 1 ) );
 
 #endif
 
@@ -75,7 +75,7 @@ LUA_FUNCTION_STATIC( index )
 
 	LUA->Pop( 2 );
 
-	lua_getfenv( LUA->state, 1 );
+	lua_getfenv( LUA->GetState(), 1 );
 	LUA->Push( 2 );
 	LUA->RawGet( -2 );
 	return 1;
@@ -85,7 +85,7 @@ LUA_FUNCTION_STATIC( newindex )
 {
 	CheckType( LUA, 1 );
 
-	lua_getfenv( LUA->state, 1 );
+	lua_getfenv( LUA->GetState(), 1 );
 	LUA->Push( 2 );
 	LUA->Push( 3 );
 	LUA->RawSet( -3 );

--- a/source/hmac.cpp
+++ b/source/hmac.cpp
@@ -26,7 +26,7 @@ static const char *table_name = "hmac";
 inline void CheckType( GarrysMod::Lua::ILuaBase *LUA, int32_t index )
 {
 	if( !LUA->IsType( index, metatype ) )
-		luaL_typerror( LUA->state, index, metaname );
+		luaL_typerror( LUA->GetState(), index, metaname );
 }
 
 static CryptoPP::HMAC_Base *GetUserData( GarrysMod::Lua::ILuaBase *LUA, int32_t index )
@@ -49,11 +49,11 @@ LUA_FUNCTION_STATIC( tostring )
 
 #if defined _WIN32
 
-	lua_pushfstring( LUA->state, "%s: %p", metaname, Get( LUA, 1 ) );
+	lua_pushfstring( LUA->GetState(), "%s: %p", metaname, Get( LUA, 1 ) );
 
 #elif defined __linux || defined __APPLE__
 
-	lua_pushfstring( LUA->state, "%s: 0x%p", metaname, Get( LUA, 1 ) );
+	lua_pushfstring( LUA->GetState(), "%s: 0x%p", metaname, Get( LUA, 1 ) );
 
 #endif
 
@@ -78,7 +78,7 @@ LUA_FUNCTION_STATIC( index )
 
 	LUA->Pop( 2 );
 
-	lua_getfenv( LUA->state, 1 );
+	lua_getfenv( LUA->GetState(), 1 );
 	LUA->Push( 2 );
 	LUA->RawGet( -2 );
 	return 1;
@@ -88,7 +88,7 @@ LUA_FUNCTION_STATIC( newindex )
 {
 	CheckType( LUA, 1 );
 
-	lua_getfenv( LUA->state, 1 );
+	lua_getfenv( LUA->GetState(), 1 );
 	LUA->Push( 2 );
 	LUA->Push( 3 );
 	LUA->RawSet( -3 );

--- a/source/hmac.cpp
+++ b/source/hmac.cpp
@@ -26,7 +26,7 @@ static const char *table_name = "hmac";
 inline void CheckType( GarrysMod::Lua::ILuaBase *LUA, int32_t index )
 {
 	if( !LUA->IsType( index, metatype ) )
-		luaL_typerror( LUA->GetState(), index, metaname );
+		luaL_typerror( LUA->GetState( ), index, metaname );
 }
 
 static CryptoPP::HMAC_Base *GetUserData( GarrysMod::Lua::ILuaBase *LUA, int32_t index )
@@ -49,11 +49,11 @@ LUA_FUNCTION_STATIC( tostring )
 
 #if defined _WIN32
 
-	lua_pushfstring( LUA->GetState(), "%s: %p", metaname, Get( LUA, 1 ) );
+	lua_pushfstring( LUA->GetState( ), "%s: %p", metaname, Get( LUA, 1 ) );
 
 #elif defined __linux || defined __APPLE__
 
-	lua_pushfstring( LUA->GetState(), "%s: 0x%p", metaname, Get( LUA, 1 ) );
+	lua_pushfstring( LUA->GetState( ), "%s: 0x%p", metaname, Get( LUA, 1 ) );
 
 #endif
 
@@ -78,7 +78,7 @@ LUA_FUNCTION_STATIC( index )
 
 	LUA->Pop( 2 );
 
-	lua_getfenv( LUA->GetState(), 1 );
+	lua_getfenv( LUA->GetState( ), 1 );
 	LUA->Push( 2 );
 	LUA->RawGet( -2 );
 	return 1;
@@ -88,7 +88,7 @@ LUA_FUNCTION_STATIC( newindex )
 {
 	CheckType( LUA, 1 );
 
-	lua_getfenv( LUA->GetState(), 1 );
+	lua_getfenv( LUA->GetState( ), 1 );
 	LUA->Push( 2 );
 	LUA->Push( 3 );
 	LUA->RawSet( -3 );


### PR DESCRIPTION
I have updated all mentions of `LUA->state` to `LUA->GetState()` which is the most correct way to retrieve the underlying lua_State object in recent versions of `garrysmod_common`